### PR TITLE
Update shebang for support on Linux

### DIFF
--- a/har2csv.jq
+++ b/har2csv.jq
@@ -1,4 +1,4 @@
-#!/usr/bin/env jq -rMf
+#!/usr/bin/jq -rMf 
 
 # Quickly convert a HTTP Archive file (har) to a CSV file.
 

--- a/har2csv.jq
+++ b/har2csv.jq
@@ -1,4 +1,4 @@
-#!/usr/bin/jq -rMf 
+#!/usr/bin/jq -rMf
 
 # Quickly convert a HTTP Archive file (har) to a CSV file.
 

--- a/har2tsv.jq
+++ b/har2tsv.jq
@@ -1,4 +1,4 @@
-#!/usr/bin/env jq -rMf
+#!/usr/bin/jq -rMf
 
 # Quickly convert a HTTP Archive file (har) to a TSV file.
 


### PR DESCRIPTION
The previous syntax is unsupported on Linux-based OS. I have also tested on Mac OS and it still works there too.